### PR TITLE
fix: Fix frame-rate and resolution auto-detection edge case

### DIFF
--- a/streamer/autodetect.py
+++ b/streamer/autodetect.py
@@ -122,7 +122,7 @@ def get_frame_rate(input: Input) -> Optional[float]:
   # '30000/1001'.  Occasionally, there is a pipe after the framerate, such as
   # '32700/1091|'.  We must split it into pieces and do the division to get a
   # float.
-  fraction = frame_rate_string.split('|')[0].split('/')
+  fraction = frame_rate_string.rstrip('|').split('/')
   if len(fraction) == 1:
     frame_rate = float(fraction[0])
   else:
@@ -146,9 +146,10 @@ def get_resolution(input: Input) -> Optional[VideoResolutionName]:
     return None
 
   # This is the resolution of the video in the form of 'WIDTH|HEIGHT'.  For
-  # example, '1920|1080'.  We have to split up width and height and match that
+  # example, '1920|1080'.  Occasionally, there is a pipe after the resolution, 
+  # such as '1920|1080|'.  We have to split up width and height and match that
   # to a named resolution.
-  width_string, height_string = resolution_string.split('|')
+  width_string, height_string = resolution_string.rstrip('|').split('|')
   width, height = int(width_string), int(height_string)
 
   for bucket in VideoResolution.sorted_values():


### PR DESCRIPTION
MOV videos captured with iPhone (iOS 16) contain a pipe character right after the frame-rate and the resolution strings, e.g. `32700/1091|` and `1920|1080|`.

Related issue: https://github.com/shaka-project/shaka-streamer/issues/127

Example ffprobe:

```
  /Users/hmishinev/Downloads/IMG_4348.mov \
  -select_streams v:0 -show_entries stream=avg_frame_rate -of compact=p=0:nk=1
ffprobe version 5.1 Copyright (c) 2007-2022 the FFmpeg developers
  built with Apple clang version 13.1.6 (clang-1316.0.21.2.5)
  configuration: --prefix=/opt/homebrew/Cellar/ffmpeg/5.1 --enable-shared --enable-pthreads --enable-version3 --cc=clang --host-cflags= --host-ldflags= --enable-ffplay --enable-gnutls --enable-gpl --enable-libaom --enable-libbluray --enable-libdav1d --enable-libmp3lame --enable-libopus --enable-librav1e --enable-librist --enable-librubberband --enable-libsnappy --enable-libsrt --enable-libtesseract --enable-libtheora --enable-libvidstab --enable-libvmaf --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxml2 --enable-libxvid --enable-lzma --enable-libfontconfig --enable-libfreetype --enable-frei0r --enable-libass --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-libspeex --enable-libsoxr --enable-libzmq --enable-libzimg --disable-libjack --disable-indev=jack --enable-videotoolbox --enable-neon
  libavutil      57. 28.100 / 57. 28.100
  libavcodec     59. 37.100 / 59. 37.100
  libavformat    59. 27.100 / 59. 27.100
  libavdevice    59.  7.100 / 59.  7.100
  libavfilter     8. 44.100 /  8. 44.100
  libswscale      6.  7.100 /  6.  7.100
  libswresample   4.  7.100 /  4.  7.100
  libpostproc    56.  6.100 / 56.  6.100
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from '/Users/hmishinev/Downloads/IMG_4348.mov':
  Metadata:
    major_brand     : qt
    minor_version   : 0
    compatible_brands: qt
    creation_time   : 2022-10-28T06:57:53.000000Z
    com.apple.quicktime.location.accuracy.horizontal: 5.000000
    com.apple.quicktime.location.ISO6709: +42.4917+027.4655+019.820/
    com.apple.quicktime.make: Apple
    com.apple.quicktime.model: iPhone 12 Pro Max
    com.apple.quicktime.software: 16.0.3
    com.apple.quicktime.creationdate: 2022-10-28T09:57:53+0300
  Duration: 00:00:10.91, start: 0.000000, bitrate: 10873 kb/s
  Stream #0:0[0x1](und): Video: hevc (Main 10) (hvc1 / 0x31637668), yuv420p10le(tv, bt2020nc/bt2020/arib-std-b67), 1920x1080, 10663 kb/s, 29.97 fps, 29.97 tbr, 600 tbn (default)
    Metadata:
      creation_time   : 2022-10-28T06:57:53.000000Z
      handler_name    : Core Media Video
      vendor_id       : [0][0][0][0]
      encoder         : HEVC
    Side data:
      DOVI configuration record: version: 1.0, profile: 8, level: 4, rpu flag: 1, el flag: 0, bl flag: 1, compatibility id: 4
      displaymatrix: rotation of -90.00 degrees
  Stream #0:1[0x2](und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 164 kb/s (default)
    Metadata:
      creation_time   : 2022-10-28T06:57:53.000000Z
      handler_name    : Core Media Audio
      vendor_id       : [0][0][0][0]
  Stream #0:2[0x3](und): Data: none (mebx / 0x7862656D), 0 kb/s (default)
    Metadata:
      creation_time   : 2022-10-28T06:57:53.000000Z
      handler_name    : Core Media Metadata
  Stream #0:3[0x4](und): Data: none (mebx / 0x7862656D), 0 kb/s (default)
    Metadata:
      creation_time   : 2022-10-28T06:57:53.000000Z
      handler_name    : Core Media Metadata
  Stream #0:4[0x5](und): Data: none (mebx / 0x7862656D), 34 kb/s (default)
    Metadata:
      creation_time   : 2022-10-28T06:57:53.000000Z
      handler_name    : Core Media Metadata
Unsupported codec with id 0 for input stream 2
Unsupported codec with id 0 for input stream 3
Unsupported codec with id 0 for input stream 4
32700/1091|
```
```
➜  shaka-streamer git:(fix-frame-rate-and-resolution-detection) ffprobe \
  /Users/hmishinev/Downloads/IMG_4348.mov \
  -select_streams v:0 -show_entries stream=width,height -of compact=p=0:nk=1
ffprobe version 5.1 Copyright (c) 2007-2022 the FFmpeg developers
  built with Apple clang version 13.1.6 (clang-1316.0.21.2.5)
  configuration: --prefix=/opt/homebrew/Cellar/ffmpeg/5.1 --enable-shared --enable-pthreads --enable-version3 --cc=clang --host-cflags= --host-ldflags= --enable-ffplay --enable-gnutls --enable-gpl --enable-libaom --enable-libbluray --enable-libdav1d --enable-libmp3lame --enable-libopus --enable-librav1e --enable-librist --enable-librubberband --enable-libsnappy --enable-libsrt --enable-libtesseract --enable-libtheora --enable-libvidstab --enable-libvmaf --enable-libvorbis --enable-libvpx --enable-libwebp --enable-libx264 --enable-libx265 --enable-libxml2 --enable-libxvid --enable-lzma --enable-libfontconfig --enable-libfreetype --enable-frei0r --enable-libass --enable-libopencore-amrnb --enable-libopencore-amrwb --enable-libopenjpeg --enable-libspeex --enable-libsoxr --enable-libzmq --enable-libzimg --disable-libjack --disable-indev=jack --enable-videotoolbox --enable-neon
  libavutil      57. 28.100 / 57. 28.100
  libavcodec     59. 37.100 / 59. 37.100
  libavformat    59. 27.100 / 59. 27.100
  libavdevice    59.  7.100 / 59.  7.100
  libavfilter     8. 44.100 /  8. 44.100
  libswscale      6.  7.100 /  6.  7.100
  libswresample   4.  7.100 /  4.  7.100
  libpostproc    56.  6.100 / 56.  6.100
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from '/Users/hmishinev/Downloads/IMG_4348.mov':
  Metadata:
    major_brand     : qt
    minor_version   : 0
    compatible_brands: qt
    creation_time   : 2022-10-28T06:57:53.000000Z
    com.apple.quicktime.location.accuracy.horizontal: 5.000000
    com.apple.quicktime.location.ISO6709: +42.4917+027.4655+019.820/
    com.apple.quicktime.make: Apple
    com.apple.quicktime.model: iPhone 12 Pro Max
    com.apple.quicktime.software: 16.0.3
    com.apple.quicktime.creationdate: 2022-10-28T09:57:53+0300
  Duration: 00:00:10.91, start: 0.000000, bitrate: 10873 kb/s
  Stream #0:0[0x1](und): Video: hevc (Main 10) (hvc1 / 0x31637668), yuv420p10le(tv, bt2020nc/bt2020/arib-std-b67), 1920x1080, 10663 kb/s, 29.97 fps, 29.97 tbr, 600 tbn (default)
    Metadata:
      creation_time   : 2022-10-28T06:57:53.000000Z
      handler_name    : Core Media Video
      vendor_id       : [0][0][0][0]
      encoder         : HEVC
    Side data:
      DOVI configuration record: version: 1.0, profile: 8, level: 4, rpu flag: 1, el flag: 0, bl flag: 1, compatibility id: 4
      displaymatrix: rotation of -90.00 degrees
  Stream #0:1[0x2](und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 164 kb/s (default)
    Metadata:
      creation_time   : 2022-10-28T06:57:53.000000Z
      handler_name    : Core Media Audio
      vendor_id       : [0][0][0][0]
  Stream #0:2[0x3](und): Data: none (mebx / 0x7862656D), 0 kb/s (default)
    Metadata:
      creation_time   : 2022-10-28T06:57:53.000000Z
      handler_name    : Core Media Metadata
  Stream #0:3[0x4](und): Data: none (mebx / 0x7862656D), 0 kb/s (default)
    Metadata:
      creation_time   : 2022-10-28T06:57:53.000000Z
      handler_name    : Core Media Metadata
  Stream #0:4[0x5](und): Data: none (mebx / 0x7862656D), 34 kb/s (default)
    Metadata:
      creation_time   : 2022-10-28T06:57:53.000000Z
      handler_name    : Core Media Metadata
Unsupported codec with id 0 for input stream 2
Unsupported codec with id 0 for input stream 3
Unsupported codec with id 0 for input stream 4
1920|1080|
```
