### PR TITLE
test: Add --no-cleanup and --filter flags to test runner

### DIFF
--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -19,6 +19,7 @@ module.exports = function(config) {
     browserNoActivityTimeout: 5 * 60 * 1000, // Disconnect after 5m silence
     client: {
       captureConsole: true,
+      filter: config.filter,
     },
     frameworks: ['jasmine'],
     files: [

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -21,6 +21,23 @@ const TEST_DIR = 'test_assets/';
 let player;
 let video;
 
+const jasmineEnv = jasmine.getEnv();
+const originalJasmineExecute = jasmineEnv.execute.bind(jasmineEnv);
+jasmineEnv.execute = () => {
+  // Match exact text or regexp if --filter is set, else empty string will match
+  // all.
+  const filterText = __karma__.config.filter || '';
+  const filterRegExp = new RegExp(filterText);
+
+  // Set jasmine config.
+  jasmineEnv.configure({
+    specFilter: (spec) => spec.getFullName().includes(filterText) ||
+                          filterRegExp.test(spec.getFullName()),
+  });
+
+  originalJasmineExecute();
+};
+
 async function startStreamer(inputConfig, pipelineConfig, bitrateConfig={}, outputLocation=OUTPUT_DIR) {
   // Send a request to flask server to start Shaka Streamer.
   const response = await fetch(flaskServerUrl + 'start', {


### PR DESCRIPTION
The --no-cleanup flag allows you to inspect the output files after a test run, for debugging purposes.

The --filter flag lets you run a subset of tests based on a text or regex match (matches if either technique matches, so you don't have to regex-escape an exact test name).