### PR TITLE
test: Fix multiperiod tests

### DIFF
--- a/run_end_to_end_tests.py
+++ b/run_end_to_end_tests.py
@@ -33,7 +33,6 @@ from mypy import api as mypy_api
 from streamer import node_base
 from streamer.controller_node import ControllerNode
 from streamer.configuration import ConfigError
-from werkzeug.utils import secure_filename
 
 OUTPUT_DIR = 'output_files/'
 TEST_DIR = 'test_assets/'
@@ -218,7 +217,10 @@ def stop():
 
 @app.route('/output_files/<path:filename>', methods = ['GET', 'OPTIONS'])
 def send_file(filename):
-  filename = secure_filename(filename)
+  if '..' in filename:
+    return createCrossOriginResponse(
+        status=400, body='Bad request, attempted to break out of output path!')
+
   if not controller:
     return createCrossOriginResponse(
         status=403, body='Instance already shut down!')


### PR DESCRIPTION
Multiperiod tests make requests for content in subfolders of the output folder.  However, the werkzeug utility "secure_filename" ruins this by replacing "/" with "_".

secure_filename() was used to prevent breakout attempts (requests for "../../../../../../../boot/vmlinuz" for example), but was intended by its authors for use in file uploads where a single filename was given, not a full path.  So we replace this with a simple check for ".." in the path.

This went unnoticed since the introduction of multi-period support because there was no GitHub Actions workflow to run the tests.