### PR TITLE
feat: Expand binary platforms and hardware encoding

### DIFF
--- a/binaries/build_wheels.py
+++ b/binaries/build_wheels.py
@@ -58,9 +58,11 @@ FFMPEG_BINARIES_DL = [
 PACKAGER_BINARIES_DL = [
     PACKAGER_DL_PREFIX + '/packager',
 ]
-UBUNTU_SUFFIXES = map(
+# Important: wrap map() in list(), because map returns an iterator, and we need
+# a real list.
+UBUNTU_SUFFIXES = list(map(
     lambda version: '-ubuntu-{}'.format(version),
-    streamer_binaries._ubuntu_versions_with_hw_encoders)
+    streamer_binaries._ubuntu_versions_with_hw_encoders))
 
 BINARIES_ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
 

--- a/binaries/setup.py
+++ b/binaries/setup.py
@@ -43,8 +43,7 @@ setuptools.setup(
       streamer_binaries.__name__: platform_binaries,
   },
   install_requires=[
-      # This is only used for Linux, and only supports Linux, but can be
-      # installed on all platforms and won't crash if imported or run.
-      'distro',
+      # This is only used for Linux, and only supports Linux.
+      'distro;platform_system=="Linux"',
   ],
 )

--- a/binaries/setup.py
+++ b/binaries/setup.py
@@ -41,5 +41,10 @@ setuptools.setup(
   package_data={
       # Only add the corresponding platform specific binaries to the wheel.
       streamer_binaries.__name__: platform_binaries,
-  }
+  },
+  install_requires=[
+      # This is only used for Linux, and only supports Linux, but can be
+      # installed on all platforms and won't crash if imported or run.
+      'distro',
+  ],
 )

--- a/binaries/streamer_binaries/__init__.py
+++ b/binaries/streamer_binaries/__init__.py
@@ -1,7 +1,8 @@
+import distro
 import os
 import platform
 
-__version__ = '0.5.2'
+__version__ = '0.6.0'
 
 
 # Get the directory path where this __init__.py file resides.
@@ -21,6 +22,12 @@ _cpu = {
   'aarch64': 'arm64',
 }[platform.machine()]
 
+# Specific versions of Ubuntu with special builds for hardware-encoding.
+_ubuntu_versions_with_hw_encoders = (
+  '22.04',
+  '24.04',
+)
+
 # Module level variables.
 ffmpeg = os.path.join(_dir_path, 'ffmpeg-{}-{}'.format(_os, _cpu))
 """The path to the installed FFmpeg binary."""
@@ -31,3 +38,11 @@ ffprobe = os.path.join(_dir_path, 'ffprobe-{}-{}'.format(_os, _cpu))
 packager = os.path.join(_dir_path, 'packager-{}-{}'.format(_os, _cpu))
 """The path to the installed Shaka Packager binary."""
 
+# Special overrides for Ubuntu builds with hardware encoding support.
+# These are not static binaries, and so they must be matched to the distro.
+if _os == 'linux':
+  if distro.id() == 'ubuntu':
+    if distro.version() in _ubuntu_versions_with_hw_encoders:
+      suffix = '-ubuntu-{}'.format(distro.version())
+      ffmpeg += suffix
+      ffprobe += suffix

--- a/binaries/streamer_binaries/__init__.py
+++ b/binaries/streamer_binaries/__init__.py
@@ -43,6 +43,6 @@ packager = os.path.join(_dir_path, 'packager-{}-{}'.format(_os, _cpu))
 if _os == 'linux':
   if distro.id() == 'ubuntu':
     if distro.version() in _ubuntu_versions_with_hw_encoders:
-      suffix = '-ubuntu-{}'.format(distro.version())
+      suffix = '-ubuntu-' + distro.version()
       ffmpeg += suffix
       ffprobe += suffix

--- a/streamer/__init__.py
+++ b/streamer/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.5.1'
+__version__ = '0.6.0'
 
 from . import controller_node

--- a/streamer/controller_node.py
+++ b/streamer/controller_node.py
@@ -30,10 +30,11 @@ import tempfile
 
 from typing import Any, Dict, List, Optional, Tuple, Union
 from streamer import __version__
+from streamer import autodetect
+from streamer import min_versions
 from streamer.cloud_node import CloudNode
 from streamer.bitrate_configuration import BitrateConfig, AudioChannelLayout, VideoResolution
 from streamer.external_command_node import ExternalCommandNode
-from streamer import autodetect
 from streamer.input_configuration import InputConfig, InputType, MediaType, Input
 from streamer.node_base import NodeBase, ProcessStatus
 from streamer.output_stream import AudioOutputStream, OutputStream, TextOutputStream, VideoOutputStream
@@ -134,16 +135,17 @@ class ControllerNode(object):
               exact_match=True,
               addendum='Install with: {}'.format(pip_command))
       else:
-        # Check that ffmpeg version is 4.1 or above.
-        _check_command_version('FFmpeg', ['ffmpeg', '-version'], (4, 1))
+        # Check the ffmpeg version.
+        _check_command_version('FFmpeg', ['ffmpeg', '-version'],
+                               min_versions.FFMPEG)
 
-        # Check that ffprobe version (used for autodetect features) is 4.1 or
-        # above.
-        _check_command_version('ffprobe', ['ffprobe', '-version'], (4, 1))
+        # Check the ffprobe version (used for autodetect features).
+        _check_command_version('ffprobe', ['ffprobe', '-version'],
+                               min_versions.FFMPEG)
 
-        # Check that Shaka Packager version is 2.6.0 or above.
+        # Check the Shaka Packager version.
         _check_command_version('Shaka Packager', ['packager', '-version'],
-                               (2, 6, 1))
+                               min_versions.PACKAGER)
 
       if bucket_url:
         # Check that the Google Cloud SDK is at least v212, which introduced

--- a/streamer/min_versions.py
+++ b/streamer/min_versions.py
@@ -1,0 +1,19 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Minimum versions of tools we depend on."""
+
+# These are minimum semantic versions expressed as tuples of ints.
+FFMPEG = (7, 1)
+PACKAGER = (3, 2, 0)

--- a/streamer/transcoder_node.py
+++ b/streamer/transcoder_node.py
@@ -292,16 +292,8 @@ class TranscoderNode(PolitelyWaitOnFinish):
           '-cpu-used', '8',
           # According to the wiki (https://trac.ffmpeg.org/wiki/Encode/AV1),
           # this allows threaded encoding in AV1, which makes better use of CPU
-          # resources and speeds up encoding.  This will be ignored by libaom
-          # before version 1.0.0-759-g90a15f4f2, and so there may be no benefit
-          # unless libaom and ffmpeg are built from source (as of Oct 2019).
+          # resources and speeds up encoding.
           '-row-mt', '1',
-          # According to the wiki (https://trac.ffmpeg.org/wiki/Encode/AV1),
-          # this allows for threaded _decoding_ in AV1, which will provide a
-          # smoother playback experience for the end user.
-          '-tiles', '2x2',
-          # AV1 is considered "experimental".
-          '-strict', 'experimental',
       ]
 
     keyframe_interval = int(self._pipeline_config.segment_size *


### PR DESCRIPTION
 - Update to the latest Shaka Packager (v3.2.0) and FFmpeg (n7.1) releases
 - Add support for macOS arm64
 - Add support for hardware encoding on Ubuntu Linux 22.04 and 24.04
 - Adjust AV1 encoding options to match new FFmpeg release