### PR TITLE
test: Fix mypy types

### DIFF
--- a/streamer/proxy_node.py
+++ b/streamer/proxy_node.py
@@ -229,7 +229,7 @@ class GCSHandler(RequestHandlerBase):
                rate_limiter: RateLimiter, *args, **kwargs) -> None:
     self._bucket: google.cloud.storage.Bucket = bucket
     self._base_path: str = base_path
-    self._chunked_output: Optional[Union[BinaryIO, BufferedIOBase]] = None
+    self._chunked_output: Optional[BinaryIO] = None
 
     # The HTTP server passes *args and *kwargs that we need to pass along, but
     # don't otherwise care about.  This must happen last, or somehow our

--- a/streamer/proxy_node.py
+++ b/streamer/proxy_node.py
@@ -21,6 +21,7 @@ import traceback
 import urllib.parse
 
 from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
+from io import BufferedIOBase
 from typing import Any, BinaryIO, Optional, Union
 
 from streamer.node_base import ProcessStatus, ThreadedNodeBase
@@ -198,7 +199,7 @@ class RequestHandlerBase(BaseHTTPRequestHandler):
 
   @abc.abstractmethod
   def handle_non_chunked(self, path: str, length: int,
-                         file: BinaryIO) -> None:
+                         file: Union[BinaryIO, BufferedIOBase]) -> None:
     """Write the non-chunked data stream from |file| to the destination."""
     pass
 
@@ -228,7 +229,7 @@ class GCSHandler(RequestHandlerBase):
                rate_limiter: RateLimiter, *args, **kwargs) -> None:
     self._bucket: google.cloud.storage.Bucket = bucket
     self._base_path: str = base_path
-    self._chunked_output: Optional[BinaryIO] = None
+    self._chunked_output: Optional[Union[BinaryIO, BufferedIOBase]] = None
 
     # The HTTP server passes *args and *kwargs that we need to pass along, but
     # don't otherwise care about.  This must happen last, or somehow our
@@ -236,7 +237,7 @@ class GCSHandler(RequestHandlerBase):
     super().__init__(rate_limiter, *args, **kwargs)
 
   def handle_non_chunked(self, path: str, length: int,
-                         file: BinaryIO) -> None:
+                         file: Union[BinaryIO, BufferedIOBase]) -> None:
     # No leading slashes, or we get a blank folder name.
     full_path = (self._base_path + path).strip('/')
     blob = self._bucket.blob(full_path)
@@ -297,7 +298,7 @@ class S3Handler(RequestHandlerBase):
     super().__init__(rate_limiter, *args, **kwargs)
 
   def handle_non_chunked(self, path: str, length: int,
-                         file: BinaryIO) -> None:
+                         file: Union[BinaryIO, BufferedIOBase]) -> None:
     # No leading slashes, or we get a blank folder name.
     full_path = (self._base_path + path).strip('/')
     # length is unused here.


### PR DESCRIPTION
On some versions, mypy thinks the file handle from the web server is BinaryIO, in others, BufferedIOBase.  We don't care which it is, as both have the methods we care about.

I tried the IOBase class from "io", but I get failures on certain devices.  This is the best solution I've found so far.