### PR TITLE
ci: Fix concurrent runs of docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -18,6 +18,11 @@ defaults:
   run:
     shell: bash
 
+# If another instance of this workflow is started, cancel the old one.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   build_docs:
     name: Build docs


### PR DESCRIPTION
If two commits hit main in rapid succession, we get two concurrent runs of the docs workflow.  Let the new one replace the old one.