### PR TITLE
feat: Always use HLS session keys to improve player startup performance

### DIFF
--- a/streamer/packager_node.py
+++ b/streamer/packager_node.py
@@ -245,6 +245,7 @@ class PackagerNode(node_base.PolitelyWaitOnFinish):
       '--protection_scheme',
       encryption.protection_scheme.value,
       '--clear_lead', str(encryption.clear_lead),
+      '--create_session_keys',
     ])
 
     if encryption.protection_systems:


### PR DESCRIPTION
Since we don't support key rotation, adding this argument is safe, and it also helps ShakaPlayer reduce startup latency, as well as helping a lot in the case where HLS identity is used.