### PR TITLE
fix(HLS): Fix audio grouping by codec

### DIFF
--- a/streamer/packager_node.py
+++ b/streamer/packager_node.py
@@ -21,6 +21,7 @@ from . import input_configuration
 from . import node_base
 from . import pipeline_configuration
 
+from streamer.input_configuration import MediaType
 from streamer.output_stream import OutputStream
 from streamer.pipeline_configuration import EncryptionMode, PipelineConfig
 from streamer.util import is_url
@@ -126,7 +127,6 @@ class PackagerNode(node_base.PolitelyWaitOnFinish):
         stdout=stdout)
 
   def _setup_stream(self, stream: OutputStream) -> str:
-
     dict = {
         'in': stream.ipc_pipe.read_end(),
         'stream': stream.type.value,
@@ -134,6 +134,9 @@ class PackagerNode(node_base.PolitelyWaitOnFinish):
 
     if stream.input.skip_encryption:
       dict['skip_encryption'] = str(stream.input.skip_encryption)
+
+    if stream.type == MediaType.AUDIO:
+      dict['hls_group_id'] = str(stream.codec.value)
 
     if stream.input.drm_label:
       dict['drm_label'] = stream.input.drm_label


### PR DESCRIPTION
Instead of something like this (Packager's default):

```
#EXT-X-MEDIA:TYPE=AUDIO,URI="aac.m3u8",GROUP-ID="audio",LANGUAGE="en",NAME="aac",DEFAULT=NO,AUTOSELECT=YES,CHANNELS="2"
#EXT-X-MEDIA:TYPE=AUDIO,URI="ac3.m3u8",GROUP-ID="audio",LANGUAGE="en",NAME="ac3",DEFAULT=NO,AUTOSELECT=YES,CHANNELS="2"

#EXT-X-STREAM-INF:BANDWIDTH=973060,AVERAGE-BANDWIDTH=973259,CODECS="avc1.4d401e,mp4a.40.2,ac3",RESOLUTION=846x360,FRAME-RATE=24.000,AUDIO="audio",CLOSED-CAPTIONS=NONE
video.m3u8
```

We should split the audio groups by codec:

```
#EXT-X-MEDIA:TYPE=AUDIO,URI="aac.m3u8",GROUP-ID="aac",LANGUAGE="en",NAME="aac",DEFAULT=NO,AUTOSELECT=YES,CHANNELS="2"
#EXT-X-MEDIA:TYPE=AUDIO,URI="ac3.m3u8",GROUP-ID="ac3",LANGUAGE="en",NAME="ac3",DEFAULT=NO,AUTOSELECT=YES,CHANNELS="2"

#EXT-X-STREAM-INF:BANDWIDTH=973060,AVERAGE-BANDWIDTH=973259,CODECS="avc1.4d401e,mp4a.40.2",RESOLUTION=846x360,FRAME-RATE=24.000,AUDIO="aac",CLOSED-CAPTIONS=NONE
video.m3u8

#EXT-X-STREAM-INF:BANDWIDTH=973060,AVERAGE-BANDWIDTH=973259,CODECS="avc1.4d401e,ac3",RESOLUTION=846x360,FRAME-RATE=24.000,AUDIO="ac3",CLOSED-CAPTIONS=NONE
video.m3u8
```

This can be done in the stream descriptor config for Shaka Packager.  Streamer will now always split up audio groups by codec.