### PR TITLE
fix(binaries): Bring PyPi package size under the limit

### DIFF
--- a/binaries/build_wheels.py
+++ b/binaries/build_wheels.py
@@ -51,11 +51,12 @@ PACKAGER_DL_PREFIX = 'https://github.com/shaka-project/shaka-packager/releases/d
 # The download links to each binary.  These download links aren't complete.
 # They are missing the platfrom-specific suffix and optional distro-specific
 # suffix (Linux only).
-FFMPEG_BINARIES_DL = [
+DISTRO_BINARIES_DL = [
     FFMPEG_DL_PREFIX + '/ffmpeg',
-    FFMPEG_DL_PREFIX + '/ffprobe',
 ]
-PACKAGER_BINARIES_DL = [
+# These don't have distro-specific suffixes on Linux.
+NON_DISTRO_BINARIES_DL = [
+    FFMPEG_DL_PREFIX + '/ffprobe',
     PACKAGER_DL_PREFIX + '/packager',
 ]
 # Important: wrap map() in list(), because map returns an iterator, and we need
@@ -123,15 +124,15 @@ def main():
 
     # Use the suffix specific to this platfrom to construct the full download
     # link for each binary.
-    for binary_dl in PACKAGER_BINARIES_DL:
+    for binary_dl in NON_DISTRO_BINARIES_DL:
       download_link = binary_dl + suffix
       binary_name = download_binary(download_url=download_link,
                                     download_dir=download_dir)
       binaries_to_include.append(binary_name)
 
-    # FFmpeg binaries are like packager binaries, except we have extra variants
-    # for Ubuntu Linux to support hardware encoding.
-    for binary_dl in FFMPEG_BINARIES_DL:
+    # FFmpeg binaries have extra variants for Ubuntu Linux to support hardware
+    # encoding.
+    for binary_dl in DISTRO_BINARIES_DL:
       download_link = binary_dl + suffix
       binary_name = download_binary(download_url=download_link,
                                     download_dir=download_dir)

--- a/binaries/streamer_binaries/__init__.py
+++ b/binaries/streamer_binaries/__init__.py
@@ -47,4 +47,3 @@ if _os == 'linux':
     if distro.version() in _ubuntu_versions_with_hw_encoders:
       suffix = '-ubuntu-' + distro.version()
       ffmpeg += suffix
-      ffprobe += suffix


### PR DESCRIPTION
According to https://pypi.org/help/#file-size-limit, there is a limit of 100MB for any given wheel.  Our Linux x64 wheel is 101MB, and so the 1.0.0 release failed to upload.

This reduces the binary size by avoiding distro-specific versions of ffprobe.  The only thing we get from distro-specific versions of ffmpeg is hardware-encoding support, but that doesn't apply to ffprobe.  So it was wasteful to include distro-specific ffprobe builds.

This reduces the Linux x64 wheel size from 101MB to 69MB.