### PR TITLE
fix(binaries): Fix arm64 mac binary tags

### DIFF
--- a/binaries/build_wheels.py
+++ b/binaries/build_wheels.py
@@ -39,8 +39,8 @@ PLATFORM_SUFFIXES = {
     'manylinux2014_aarch64': '-linux-arm64',
     # macOS x64 with 10.9 SDK
     'macosx_10_9_x86_64': '-osx-x64',
-    # macOS arm64 with 10.9 SDK
-    'macosx_10_9_arm64': '-osx-arm64',
+    # macOS arm64 with 11.0 SDK
+    'macosx_11_0_arm64': '-osx-arm64',
     # Windows x64
     'win_amd64': '-win-x64.exe',
 }


### PR DESCRIPTION
I used docs on the [Python wheel format][] to determine that the bit with the OS and CPU is called the "platform tag".  Then I found a [discussion of macOS platform tags][] that gave me the hint that arm64 wheels need to specify macOS 11 at a minimum.

[Python wheel format]: https://peps.python.org/pep-0427/
[discussion of macOS platform tags]: https://github.com/pypa/wheel/issues/387

Closes #194