### PR TITLE
fix(binaries): Fix macOS arm64 ffmpeg crash

### DIFF
--- a/binaries/build_wheels.py
+++ b/binaries/build_wheels.py
@@ -26,7 +26,7 @@ import streamer_binaries
 
 # Version constants.
 # Change to download different versions.
-FFMPEG_VERSION = 'n7.1-1'
+FFMPEG_VERSION = 'n7.1-2'
 PACKAGER_VERSION = 'v3.3.0'
 
 # A map of suffixes that will be combined with the binary download links


### PR DESCRIPTION
See https://github.com/shaka-project/static-ffmpeg-binaries/issues/51 and https://github.com/shaka-project/static-ffmpeg-binaries/pull/54