### PR TITLE
feat: Use by default VP9 with mp4

### DIFF
--- a/streamer/bitrate_configuration.py
+++ b/streamer/bitrate_configuration.py
@@ -109,13 +109,8 @@ class VideoCodec(enum.Enum):
 
   def get_output_format(self) -> str:
     """Returns an FFmpeg output format suitable for this codec."""
-    # TODO: consider VP9 in mp4 by default
-    # TODO(#31): add support for configurable output format per-codec
-    if self == VideoCodec.VP9:
-      return 'webm'
-    elif self in {VideoCodec.H264, VideoCodec.HEVC}:
-      return 'mp4'
-    elif self == VideoCodec.AV1:
+    # TODO(#31): add support for configurable output format per-codec (mp4 or webm)
+    if self in {VideoCodec.H264, VideoCodec.VP9, VideoCodec.HEVC, VideoCodec.AV1}:
       return 'mp4'
     else:
       assert False, 'No mapping for output format for codec {}'.format(

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -845,32 +845,6 @@ function codecTests(manifestUrl, format) {
     codecList = codecList.map((x) => x.replace('hvc1', 'hev1'));
     expect(codecList).toEqual(['hev1.1.6.L60.90']);
   });
-
-  it('appropriately filters WebM formats ' + format, async () => {
-    const inputConfigDict = {
-      'inputs': [
-        {
-          'name': TEST_DIR + 'Sintel.2010.720p.Small.mkv',
-          'media_type': 'video',
-          // Keep this test short by only encoding 1s of content.
-          'end_time': '0:01',
-        },
-      ],
-    };
-    const pipelineConfigDict = {
-      'streaming_mode': 'vod',
-      'resolutions': ['144p'],
-      'video_codecs': ['h264', 'vp9'],
-    };
-    await startStreamer(inputConfigDict, pipelineConfigDict);
-
-    let codecList = await getAudioAndVideoCodecs(manifestUrl);
-    if (manifestUrl == hlsManifestUrl) {
-      expect(codecList).not.toContain(jasmine.stringMatching('vp09.*'));
-    } else if (manifestUrl == dashManifestUrl) {
-      expect(codecList).toContain(jasmine.stringMatching('vp09.*'));
-    }
-  })
 }
 
 function autoDetectionTests(manifestUrl) {


### PR DESCRIPTION
VP9 in MP4 has been supported in Chrome since Chrome 60 (https://chromestatus.com/feature/5762080762232832), which was released in June 2017, so it's been over 7 years!