### PR TITLE
test: Fix Shaka Player warning

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -124,12 +124,13 @@ describe('Shaka Streamer', () => {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 400 * 1000;
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     video = document.createElement('video');
     video.muted = true;
     document.body.appendChild(video);
 
-    player = new shaka.Player(video);
+    player = new shaka.Player();
+    await player.attach(video);
     const retryParameters = {
       maxAttempts: 5,
       timeout: 90e3,


### PR DESCRIPTION
`WARN LOG: 'Player w/ mediaElement has been deprecated and will be removed in v5.0 . We are currently at version v4.11 . Additional information: Please migrate from initializing Player with a mediaElement; use the attach method instead.'`