### PR TITLE
feat: Recover from upload failures

### DIFF
--- a/binaries/build_wheels.py
+++ b/binaries/build_wheels.py
@@ -27,7 +27,7 @@ import streamer_binaries
 # Version constants.
 # Change to download different versions.
 FFMPEG_VERSION = 'n7.1-2'
-PACKAGER_VERSION = 'v3.3.0'
+PACKAGER_VERSION = 'v3.4.0'
 
 # A map of suffixes that will be combined with the binary download links
 # to achieve a full download link.  Different suffix for each platform.

--- a/streamer/min_versions.py
+++ b/streamer/min_versions.py
@@ -16,4 +16,4 @@
 
 # These are minimum semantic versions expressed as tuples of ints.
 FFMPEG = (7, 1)
-PACKAGER = (3, 2, 0)
+PACKAGER = (3, 4, 0)

--- a/streamer/packager_node.py
+++ b/streamer/packager_node.py
@@ -109,6 +109,10 @@ class PackagerNode(node_base.PolitelyWaitOnFinish):
           # Number of seconds between manifest updates.
           '--minimum_update_period',
           str(self._pipeline_config.update_period),
+          # Ignore HTTP output failures so that the pipeline doesn't stop if we
+          # fail to upload one segment.  Only enable this for live streams,
+          # since for VOD, we really should signal that failure to the user.
+          '--ignore_http_output_failures',
       ]
 
     args += self._setup_manifest_format()


### PR DESCRIPTION
Instruct Packager to ignore HTTP output failures, so that the pipeline overall doesn't fail during a live stream.  Once the system recovers, segments will be missing, but the stream overall will survive.

This requires a new release of Shaka Packager (v3.4.0).

Closes #195