### PR TITLE
fix(docs): Improve READMEs and pypi docs for binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ Sample configs can be found in the [`config_files/`] folder in the repo.
 
 [`config_files/`]: https://github.com/shaka-project/shaka-streamer/tree/main/config_files
 
-Release versions of Shaka Streamer can be installed or upgraded through `pip3`
-with:
+Install or upgrade Shaka Streamer and its [binaries][] through `pip3` with:
 
 ```sh
 # To install globally (drop the "sudo" for Windows):
-sudo pip3 install --upgrade shaka-streamer
+sudo pip3 install --upgrade shaka-streamer shaka-streamer-binaries
 
 # To install per-user:
-pip3 install --user --upgrade shaka-streamer
+pip3 install --user --upgrade shaka-streamer shaka-streamer-binaries
 ```
+
+[binaries]: https://pypi.org/project/shaka-streamer-binaries/

--- a/binaries/README.md
+++ b/binaries/README.md
@@ -1,0 +1,25 @@
+# ![Shaka Streamer](https://raw.githubusercontent.com/shaka-project/shaka-streamer/main/docs/source/shaka-streamer-logo.png)
+
+Shaka Streamer Binaries is a companion package to [Shaka Streamer][] that
+provides platform-specific binaries for Streamer's dependencies: [FFmpeg][] and
+[Shaka Packager][].
+
+FFmpeg binaries are built from open, verifiable, automated workflows at
+https://github.com/shaka-project/static-ffmpeg-binaries
+
+Shaka Packager binaries are official releases from
+https://github.com/shaka-project/shaka-packager
+
+Install or upgrade Shaka Streamer and its binaries through `pip3` with:
+
+```sh
+# To install globally (drop the "sudo" for Windows):
+sudo pip3 install --upgrade shaka-streamer shaka-streamer-binaries
+
+# To install per-user:
+pip3 install --user --upgrade shaka-streamer shaka-streamer-binaries
+```
+
+[FFmpeg]: https://ffmpeg.org/
+[Shaka Packager]: https://github.com/shaka-project/shaka-packager
+[Shaka Streamer]: https://pypi.org/project/shaka-streamer/

--- a/binaries/setup.py
+++ b/binaries/setup.py
@@ -22,14 +22,16 @@ separator_index = sys.argv.index('--')
 platform_binaries = sys.argv[separator_index + 1:]
 sys.argv = sys.argv[:separator_index]
 
+with open('README.md', 'r') as f:
+  long_description = f.read()
+
 setuptools.setup(
   name='shaka-streamer-binaries',
   version=streamer_binaries.__version__,
   author='Google',
   description='A package containing FFmpeg, FFprobe, and Shaka Packager static builds.',
-  long_description=('An auxiliary package that provides platform-specific'
-                    ' binaries used by Shaka Streamer.'),
-  long_description_content_type='text/plain',
+  long_description=long_description,
+  long_description_content_type='text/markdown',
   url='https://github.com/shaka-project/shaka-streamer/tree/main/binaries',
   packages=[streamer_binaries.__name__,],
   classifiers=[


### PR DESCRIPTION
The binary package on pypi has almost no information.  This adds a more detailed README to make the pypi landing page more explanatory.

This also improves the main README to mention the binary package.  It is strongly recommended, and should be mentioned in the brief instructions on the main package README.

Classified as a "fix" only so that the release workflow will trigger, so that we can update the docs on pypi with a new release.