### PR TITLE
chore: Fix mypy linter errors and warnings

### DIFF
--- a/streamer/bitrate_configuration.py
+++ b/streamer/bitrate_configuration.py
@@ -36,12 +36,11 @@ class BitrateString(configuration.ValidatingType, str):
 
 
 class AudioCodec(enum.Enum):
-
-  AAC: str = 'aac'
-  OPUS: str = 'opus'
-  AC3: str = 'ac3'
-  EAC3: str = 'eac3'
-  FLAC: str = 'flac'
+  AAC = 'aac'
+  OPUS = 'opus'
+  AC3 = 'ac3'
+  EAC3 = 'eac3'
+  FLAC = 'flac'
 
   def is_hardware_accelerated(self) -> bool:
     """Returns True if this codec is hardware accelerated."""

--- a/streamer/periodconcat_node.py
+++ b/streamer/periodconcat_node.py
@@ -125,7 +125,7 @@ class PeriodConcatNode(ThreadedNodeBase):
       self._pipeline_config.dash_output)).getroot()
 
     # Get the default namespace.
-    namespace_matches = re.search('\{([^}]*)\}', concat_mpd.tag)
+    namespace_matches = re.search(r'\{([^}]*)\}', concat_mpd.tag)
     assert namespace_matches is not None, 'Unable to find the default namespace.'
     default_dash_namespace = namespace_matches.group(1)
 


### PR DESCRIPTION
A newer linter complains about our codec enums:

> streamer/bitrate_configuration.py:40: error: Enum members must be left unannotated  [misc]
> streamer/bitrate_configuration.py:40: note: See https://typing.readthedocs.io/en/latest/spec/enums.html#defining-members

And also this shows up in Python 3.12:

> streamer/periodconcat_node.py:128: SyntaxWarning: invalid escape sequence '\{'
>  namespace_matches = re.search('\{([^}]*)\}', concat_mpd.tag)