### PR TITLE
perf: Use a process pool to improve cloud upload performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "lint": "python3 -m mypy streamer/",
+    "lint": "python3 -m mypy streamer/ shaka-streamer",
     "test": "python3 run_end_to_end_tests.py"
   },
   "devDependencies": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 distro>=1.9,<2; platform_system == "Linux"
+setproctitle>=1,<2
 pyyaml>=6,<7
 pywin32>=308; platform_system == "Windows"

--- a/run_end_to_end_tests.py
+++ b/run_end_to_end_tests.py
@@ -345,7 +345,7 @@ def main():
   do_debug = args.debug
 
   # Do static type checking on the project first.
-  type_check_result = mypy_api.run(['streamer/'])
+  type_check_result = mypy_api.run(['streamer/', 'shaka-streamer'])
   if type_check_result[2] != 0:
     print('The type checker found the following errors: ')
     print(type_check_result[0])

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setuptools.setup(
   url='https://github.com/shaka-project/shaka-streamer',
   packages=setuptools.find_packages(),
   install_requires=[
+      'setproctitle>=1,<2',
       'pyyaml>=6,<7',
       'pywin32>=308; platform_system == "Windows"',
   ],

--- a/shaka-streamer
+++ b/shaka-streamer
@@ -28,7 +28,7 @@ https://shaka-project.github.io/shaka-streamer/
 import argparse
 import sys
 import time
-import yaml
+import yaml  # type: ignore
 
 import streamer
 

--- a/streamer/cloud/base.py
+++ b/streamer/cloud/base.py
@@ -1,0 +1,51 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Upload to cloud storage providers.
+
+Base class definition."""
+
+import abc
+
+
+class CloudUploaderBase(object):
+  @abc.abstractmethod
+  def write_non_chunked(self, path: str, data: bytes) -> None:
+    """Write the non-chunked data to the destination."""
+    pass
+
+  @abc.abstractmethod
+  def start_chunked(self, path: str) -> None:
+    """Set up for a chunked transfer to the destination."""
+    pass
+
+  @abc.abstractmethod
+  def write_chunk(self, data: bytes) -> None:
+    """Handle a single chunk of data."""
+    pass
+
+  @abc.abstractmethod
+  def end_chunked(self) -> None:
+    """End the chunked transfer."""
+    pass
+
+  @abc.abstractmethod
+  def delete(self, path: str) -> None:
+    """Delete the file from cloud storage."""
+    pass
+
+  @abc.abstractmethod
+  def reset(self) -> None:
+    """Reset any chunked output state."""
+    pass

--- a/streamer/cloud/gcs.py
+++ b/streamer/cloud/gcs.py
@@ -1,0 +1,92 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Upload to Google Cloud Storage."""
+
+import urllib.parse
+
+from typing import BinaryIO, Optional
+
+import google.cloud.storage  # type: ignore
+import google.api_core.exceptions  # type: ignore
+
+from streamer.cloud.base import CloudUploaderBase
+
+
+class GCSUploader(CloudUploaderBase):
+  """See base class for interface docs."""
+
+  def __init__(self, upload_location: str) -> None:
+    # Parse the upload location (URL).
+    url = urllib.parse.urlparse(upload_location)
+
+    self._client = google.cloud.storage.Client()
+    # If upload_location is "gs://foo/bar", url.netloc is "foo", which is the
+    # bucket name.
+    self._bucket = self._client.bucket(url.netloc)
+
+    # Strip both left and right slashes.  Otherwise, we get a blank folder name.
+    self._base_path = url.path.strip('/')
+
+    # A file-like object from the Google Cloud Storage module that we write to
+    # during a chunked upload.
+    self._chunked_output: Optional[BinaryIO] = None
+
+  def write_non_chunked(self, path: str, data: bytes) -> None:
+    # No leading slashes, or we get a blank folder name.
+    full_path = (self._base_path + path).strip('/')
+
+    # An object representing the destination blob.
+    blob = self._bucket.blob(full_path)
+    blob.cache_control = 'no-cache'
+
+    # A file-like interface to that blob.
+    output = blob.open('wb', retry=google.cloud.storage.retry.DEFAULT_RETRY)
+    output.write(data)
+    output.close()
+
+  def start_chunked(self, path: str) -> None:
+    # No leading slashes, or we get a blank folder name.
+    full_path = (self._base_path + path).strip('/')
+
+    # An object representing the destination blob.
+    blob = self._bucket.blob(full_path)
+    blob.cache_control = 'no-cache'
+
+    # A file-like interface to that blob.
+    self._chunked_output = blob.open(
+        'wb', retry=google.cloud.storage.retry.DEFAULT_RETRY)
+
+  def write_chunk(self, data: bytes) -> None:
+    assert self._chunked_output is not None
+    self._chunked_output.write(data)
+
+  def end_chunked(self) -> None:
+    self.reset()
+
+  def delete(self, path: str) -> None:
+    # No leading slashes, or we get a blank folder name.
+    full_path = (self._base_path + path).strip('/')
+    blob = self._bucket.blob(full_path)
+    try:
+      blob.delete(retry=google.cloud.storage.retry.DEFAULT_RETRY)
+    except google.api_core.exceptions.NotFound:
+      # Some delete calls seem to throw "not found", but the files still get
+      # deleted.  So ignore these and don't fail the request.
+      pass
+
+  def reset(self) -> None:
+    if self._chunked_output:
+      self._chunked_output.close()
+      self._chunked_output = None

--- a/streamer/cloud/pool.py
+++ b/streamer/cloud/pool.py
@@ -1,0 +1,214 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A pool of worker processes to upload to cloud storage."""
+
+import abc
+import enum
+from setproctitle import setproctitle  # type: ignore
+from queue import Queue
+
+from typing import Optional
+from typing_extensions import Self
+
+import multiprocessing
+from multiprocessing.connection import Connection
+
+from streamer.cloud.base import CloudUploaderBase
+import streamer.cloud.uploader as Uploader
+
+
+class MessageType(enum.Enum):
+  """Message type constants used for IPC from the main process to the pool."""
+
+  WRITE_NON_CHUNKED = 'write_non_chunked'
+  START_CHUNKED = 'start_chunked'
+  WRITE_CHUNK = 'write_chunk'
+  END_CHUNKED = 'end_chunked'
+  DELETE = 'delete'
+  RESET = 'reset'
+
+
+class Message(object):
+  """Message objects used for IPC from the main process to the pool."""
+  def __init__(self, type: MessageType, path: str = "",
+               data: bytes = b'') -> None:
+    self.type: MessageType = type
+    self.path: str = path
+    self.data: bytes = data
+
+  @staticmethod
+  def write_non_chunked(path: str, data: bytes) -> 'Message':
+    """A request to write non-chunked data (all at once)."""
+    return Message(MessageType.WRITE_NON_CHUNKED, path, data)
+
+  @staticmethod
+  def start_chunked(path: str) -> 'Message':
+    """A request to start a chunked data transfer."""
+    return Message(MessageType.START_CHUNKED, path)
+
+  @staticmethod
+  def write_chunk(data: bytes) -> 'Message':
+    """A request to write a single chunk of data."""
+    return Message(MessageType.WRITE_CHUNK, data = data)
+
+  @staticmethod
+  def end_chunked() -> 'Message':
+    """A request to end a chunked data transfer."""
+    return Message(MessageType.END_CHUNKED)
+
+  @staticmethod
+  def delete(path: str) -> 'Message':
+    """A request to delete a file."""
+    return Message(MessageType.DELETE, path)
+
+  @staticmethod
+  def reset() -> 'Message':
+    """A request to reset state when releasing a worker."""
+    return Message(MessageType.RESET)
+
+
+def worker_target(upload_location: str, reader: Connection):
+  """Target for multiprocessing.Process.
+
+  This is the entry point for every worker subprocess.
+
+  Reads messages from IPC and talks to cloud storage."""
+
+  # Set the title of the process as it appears in "ps" under Linux.
+  setproctitle('shaka-streamer cloud upload worker')
+
+  # Create an uploader using whatever vendor-specific module is necessary for
+  # this upload location URL.  (Google Cloud Storage, Amazon S3, etc.)
+  uploader = Uploader.create(upload_location)
+
+  # Wait for command messages from the main process, proxying each command to
+  # the uploader.
+  while True:
+    try:
+      message: Message = reader.recv()
+
+      if message.type == MessageType.WRITE_NON_CHUNKED:
+        uploader.write_non_chunked(message.path, message.data)
+      elif message.type == MessageType.START_CHUNKED:
+        uploader.start_chunked(message.path)
+      elif message.type == MessageType.WRITE_CHUNK:
+        uploader.write_chunk(message.data)
+      elif message.type == MessageType.END_CHUNKED:
+        uploader.end_chunked()
+      elif message.type == MessageType.DELETE:
+        uploader.delete(message.path)
+      elif message.type == MessageType.RESET:
+        uploader.reset()
+    except EOFError:
+      # Quit the process when the other end of the pipe is closed.
+      return
+
+
+class WorkerProcess(object):
+  """A worker process and the write end of its pipe."""
+
+  def __init__(self, process: multiprocessing.Process,
+               writer: Connection) -> None:
+    self.process = process
+    self.writer = writer
+
+
+class AbstractPool(object):
+  """An interface for a WorkerHandle (below) to talk to Pool (which references
+  WorkerHandle).  Created to break a circular dependency for static typing."""
+
+  @abc.abstractmethod
+  def _release(self, process: WorkerProcess) -> None:
+    """Add a process back into the pool."""
+    pass
+
+
+class WorkerHandle(CloudUploaderBase):
+  """A proxy for a cloud uploader interface that sends commands to a worker
+  process.  It is also a context manager for use with "with" statements."""
+
+  def __init__(self, pool: AbstractPool, process: WorkerProcess) -> None:
+    self._pool = pool
+    self._process = process
+
+  def __enter__(self) -> Self:
+    # Part of the interface for context managers, but there's nothing to do
+    # here.
+    return self
+
+  def __exit__(self, *args, **kwargs) -> None:
+    """Reset the subprocess's uploader and release the subprocess back to the
+    pool."""
+
+    self._process.writer.send(Message.reset())
+    self._pool._release(self._process)
+
+  def write_non_chunked(self, path: str, data: bytes) -> None:
+    self._process.writer.send(Message.write_non_chunked(path, data))
+
+  def start_chunked(self, path: str) -> None:
+    self._process.writer.send(Message.start_chunked(path))
+
+  def write_chunk(self, data: bytes) -> None:
+    self._process.writer.send(Message.write_chunk(data))
+
+  def end_chunked(self) -> None:
+    self._process.writer.send(Message.end_chunked())
+
+  def delete(self, path: str) -> None:
+    self._process.writer.send(Message.delete(path))
+
+  def reset(self) -> None:
+    # Part of the interface for uploaders, but this should not be called
+    # explicitly.
+    pass
+
+
+class Pool(AbstractPool):
+  """A pool of worker subprocesses that handle cloud upload actions."""
+
+  def __init__(self, upload_location: str, size: int) -> None:
+    self._all_processes: list[WorkerProcess] = []
+    self._available_processes: Queue[WorkerProcess] = Queue()
+
+    for i in range(size):
+      reader, writer = multiprocessing.Pipe(duplex=False)
+      process = multiprocessing.Process(target=worker_target,
+                                        args=(upload_location, reader))
+      process.start()
+      worker_process = WorkerProcess(process, writer)
+      self._available_processes.put(worker_process)
+      self._all_processes.append(worker_process)
+
+  def _release(self, worker_process: WorkerProcess) -> None:
+    """Called by worker handles to release the worker back to the pool."""
+
+    self._available_processes.put(worker_process)
+
+  def get_worker(self) -> WorkerHandle:
+    """Get an available worker.  Blocks until one is available.
+
+    Returns a WorkerHandle meant to be used as a context manager (with "with"
+    statements) so that it will be automatically released."""
+
+    worker_process = self._available_processes.get(block=True)
+    return WorkerHandle(self, worker_process)
+
+  def close(self) -> None:
+    """Close all worker processes."""
+
+    for process in self._all_processes:
+      process.writer.close()
+      process.process.join()

--- a/streamer/cloud/s3.py
+++ b/streamer/cloud/s3.py
@@ -1,0 +1,126 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Upload to Amazon S3."""
+
+import urllib.parse
+
+from typing import Any, Optional
+
+import boto3  # type: ignore
+import botocore.config  # type: ignore
+
+from streamer.cloud.base import CloudUploaderBase
+
+
+# S3 has a minimum chunk size for multipart uploads.
+MIN_S3_CHUNK_SIZE = (5 << 20)  # 5MB
+
+
+class S3Uploader(CloudUploaderBase):
+  """See base class for interface docs."""
+
+  def __init__(self, upload_location: str) -> None:
+    # Parse the upload location (URL).
+    url = urllib.parse.urlparse(upload_location)
+
+    config = botocore.config.Config(retries = {'mode': 'standard'})
+    self._client = boto3.client('s3', config=config)
+
+    # If upload_location is "s3://foo/bar", url.netloc is "foo", which is the
+    # bucket name.
+    self._bucket_name = url.netloc
+
+    # Strip both left and right slashes.  Otherwise, we get a blank folder name.
+    self._base_path = url.path.strip('/')
+
+    # State for chunked uploads:
+    self._upload_id: Optional[str] = None
+    self._upload_path: Optional[str] = None
+    self._next_part_number: int = 0
+    self._part_info: list[dict[str,Any]] = []
+    self._data: bytes = b''
+
+  def write_non_chunked(self, path: str, data: bytes) -> None:
+    # No leading slashes, or we get a blank folder name.
+    full_path = (self._base_path + path).strip('/')
+
+    # Write the whole object at once.
+    self._client.put_object(Body=data, Bucket=self._bucket_name, Key=full_path,
+                            ExtraArgs={'CacheControl': 'no-cache'})
+
+  def start_chunked(self, path: str) -> None:
+    # No leading slashes, or we get a blank folder name.
+    self._upload_path = (self._base_path + path).strip('/')
+
+    # Ask the client to start a multi-part upload.
+    response = self._client.create_multipart_upload(
+        Bucket=self._bucket_name, Key=self._upload_path,
+        CacheControl='no-cache')
+
+    # This ID is sent to subsequent calls into the S3 client.
+    self._upload_id = response['UploadId']
+
+    # We must accumulate metadata about each part to complete the file at the
+    # end of the chunked transfer.
+    self._part_info = []
+    # We must also number the parts.
+    self._next_part_number = 1
+    # Multi-part uploads for S3 can't have chunks smaller than 5MB.
+    # We accumulate data for chunks here.
+    self._data = b''
+
+  def write_chunk(self, data: bytes, force: bool = False) -> None:
+    # Collect data until we hit the minimum chunk size.
+    self._data += data
+
+    data_len = len(self._data)
+    if data_len >= MIN_S3_CHUNK_SIZE or (data_len and force):
+      # Upload one "part", which may be comprised of multiple HTTP chunks from
+      # Packager.
+      response = self._client.upload_part(
+          Bucket=self._bucket_name, Key=self._upload_path,
+          PartNumber=self._next_part_number, UploadId=self._upload_id,
+          Body=self._data)
+
+      # We have to collect this data, in this format, to finish the multipart
+      # upload later.
+      self._part_info.append({
+        'PartNumber': self._next_part_number,
+        'ETag': response['ETag'],
+      })
+      self._next_part_number += 1
+      self._data = b''
+
+  def end_chunked(self) -> None:
+    # Flush the buffer.
+    self.write_chunk(b'', force=True)
+
+    # Complete the multipart upload.
+    upload_info = { 'Parts': self._part_info }
+    self._client.complete_multipart_upload(
+        Bucket=self._bucket_name, Key=self._upload_path,
+        UploadId=self._upload_id, MultipartUpload=upload_info)
+    self.reset()
+
+  def delete(self, path: str) -> None:
+    self._client.delete_object(
+        Bucket=self._bucket_name, Key=self._upload_path)
+
+  def reset(self) -> None:
+    self._upload_id = None
+    self._upload_path = None
+    self._next_part_number = 0
+    self._part_info = []
+    self._data = b''

--- a/streamer/cloud/uploader.py
+++ b/streamer/cloud/uploader.py
@@ -1,0 +1,55 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Upload to cloud storage providers."""
+
+from streamer.cloud.base import CloudUploaderBase
+
+
+# Supported protocols.  Built based on which optional modules are available for
+# cloud storage providers.
+SUPPORTED_PROTOCOLS: list[str] = []
+
+
+# All supported protocols.  Used to provide more useful error messages.
+ALL_SUPPORTED_PROTOCOLS: list[str] = ['gs', 's3']
+
+
+# Try to load the GCS (Google Cloud Storage) uploader.  If we can, the user has
+# the libraries needed for GCS support.
+try:
+  from streamer.cloud.gcs import GCSUploader
+  SUPPORTED_PROTOCOLS.append('gs')
+except:
+  pass
+
+
+# Try to load the S3 (Amazon Cloud Storage) uploader.  If we can, the user has
+# the libraries needed for S3 support.
+try:
+  from streamer.cloud.s3 import S3Uploader
+  SUPPORTED_PROTOCOLS.append('s3')
+except:
+  pass
+
+
+def create(upload_location: str) -> CloudUploaderBase:
+  """Create an uploader appropriate to the upload location URL."""
+
+  if upload_location.startswith("gs://"):
+    return GCSUploader(upload_location)
+  elif upload_location.startswith("s3://"):
+    return S3Uploader(upload_location)
+  else:
+    raise RuntimeError("Protocol of {} isn't supported".format(upload_location))

--- a/streamer/proxy_node.py
+++ b/streamer/proxy_node.py
@@ -14,17 +14,17 @@
 
 """A simple proxy server to upload to cloud stroage providers."""
 
-import abc
-import threading
 import time
 import traceback
 import urllib.parse
 
 from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
-from io import BufferedIOBase
-from typing import Any, BinaryIO, Optional, Union
+from typing import Optional, Union
 
 from streamer.node_base import ProcessStatus, ThreadedNodeBase
+
+from streamer.cloud.pool import Pool
+from streamer.cloud.uploader import ALL_SUPPORTED_PROTOCOLS, SUPPORTED_PROTOCOLS
 
 
 # HTTP status codes
@@ -33,38 +33,10 @@ HTTP_STATUS_ACCEPTED = 202
 HTTP_STATUS_NO_CONTENT = 204
 HTTP_STATUS_FAILED = 500
 
-# S3 has a minimum chunk size for multipart uploads.
-MIN_S3_CHUNK_SIZE = (5 << 20)  # 5MB
-
-
-# Supported protocols.  Built based on which optional modules are available for
-# cloud storage providers.
-SUPPORTED_PROTOCOLS: list[str] = []
-
-# All supported protocols.  Used to provide more useful error messages.
-ALL_SUPPORTED_PROTOCOLS: list[str] = ['gs', 's3']
-
 
 # Don't write the same file more than once per rate limiter period.
 # For live streams, this avoids HTTP 429 "Too many request" errors.
 RATE_LIMITER_PERIOD_IN_SECONDS = 2
-
-
-# Optional: To support GCS, import Google Cloud Storage library.
-try:
-  import google.cloud.storage  # type: ignore
-  import google.api_core.exceptions  # type: ignore
-  SUPPORTED_PROTOCOLS.append('gs')
-except:
-  pass
-
-# Optional: To support S3, import AWS's boto3 library.
-try:
-  import boto3  # type: ignore
-  import botocore.config  # type: ignore
-  SUPPORTED_PROTOCOLS.append('s3')
-except:
-  pass
 
 
 class RateLimiter(object):
@@ -95,13 +67,15 @@ class RateLimiter(object):
     self._last_check: float = now
 
 
-class RequestHandlerBase(BaseHTTPRequestHandler):
+class RequestHandler(BaseHTTPRequestHandler):
   """A request handler that processes requests coming from Shaka Packager and
   relays them to the destination.
   """
 
-  def __init__(self, rate_limiter: RateLimiter, *args, **kwargs):
+  def __init__(self, rate_limiter: RateLimiter, pool: Pool,
+               *args, **kwargs) -> None:
     self._rate_limiter: RateLimiter = rate_limiter
+    self._pool: Pool = pool
 
     # The HTTP server passes *args and *kwargs that we need to pass along, but
     # don't otherwise care about.  This must happen last, or somehow our
@@ -128,28 +102,29 @@ class RequestHandlerBase(BaseHTTPRequestHandler):
     # Here we parse the chunked transfer encoding and delegate to the
     # subclass's start/chunk/end methods.  If |suppress|, we parse the input
     # but don't do anything with it.
-    if not suppress:
-      self.start_chunked(self.path)
+    with self._pool.get_worker() as worker:
+      if not suppress:
+        worker.start_chunked(self.path)
 
-    while True:
-      # Parse the chunk size
-      chunk_size_line = self.rfile.readline().strip()
-      chunk_size = int(chunk_size_line, 16)
+      while True:
+        # Parse the chunk size
+        chunk_size_line = self.rfile.readline().strip()
+        chunk_size = int(chunk_size_line, 16)
 
-      # Read the chunk and process it
-      if chunk_size != 0:
-        data = self.rfile.read(chunk_size)
-        if not suppress:
-          self.handle_chunk(data)
+        # Read the chunk and process it
+        if chunk_size != 0:
+          data = self.rfile.read(chunk_size)
+          if not suppress:
+            worker.write_chunk(data)
 
-      self.rfile.readline()  # Read the trailer
+        self.rfile.readline()  # Read the trailer
 
-      if chunk_size == 0:
-         break  # EOF
+        if chunk_size == 0:
+           break  # EOF
 
-    # All done.
-    if not suppress:
-      self.end_chunked()
+      # All done.
+      if not suppress:
+        worker.end_chunked()
 
   def _parse_non_chunked_transfer(self, suppress: bool) -> None:
     # We have the whole file at once, with a known length.
@@ -159,7 +134,8 @@ class RequestHandlerBase(BaseHTTPRequestHandler):
       # If |suppress|, we read the input but don't do anything with it.
       self.rfile.read(content_length)
     else:
-      self.handle_non_chunked(self.path, content_length, self.rfile)
+      with self._pool.get_worker() as worker:
+        worker.write_non_chunked(self.path, self.rfile.read(content_length))
 
   def do_PUT(self) -> None:
     """Handle PUT requests coming from Shaka Packager."""
@@ -186,7 +162,8 @@ class RequestHandlerBase(BaseHTTPRequestHandler):
   def do_DELETE(self) -> None:
     """Handle DELETE requests coming from Shaka Packager."""
     try:
-      self.handle_delete(self.path)
+      with self._pool.get_worker() as worker:
+        worker.delete(self.path)
       self.send_response(HTTP_STATUS_NO_CONTENT)
     except Exception as ex:
       print('Upload failure: ' + str(ex))
@@ -197,219 +174,62 @@ class RequestHandlerBase(BaseHTTPRequestHandler):
     # "returned nothing".
     self.end_headers()
 
-  @abc.abstractmethod
-  def handle_non_chunked(self, path: str, length: int,
-                         file: Union[BinaryIO, BufferedIOBase]) -> None:
-    """Write the non-chunked data stream from |file| to the destination."""
-    pass
 
-  @abc.abstractmethod
-  def start_chunked(self, path: str) -> None:
-    """Set up for a chunked transfer to the destination."""
-    pass
-
-  @abc.abstractmethod
-  def handle_chunk(self, data: bytes) -> None:
-    """Handle a single chunk of data."""
-    pass
-
-  @abc.abstractmethod
-  def end_chunked(self) -> None:
-    """End the chunked transfer."""
-    pass
-
-  @abc.abstractmethod
-  def handle_delete(self, path: str) -> None:
-    """Delete the file from cloud storage."""
-    pass
-
-class GCSHandler(RequestHandlerBase):
-  # Can't annotate the bucket here as a parameter if we don't have the library.
-  def __init__(self, bucket: Any, base_path: str,
-               rate_limiter: RateLimiter, *args, **kwargs) -> None:
-    self._bucket: google.cloud.storage.Bucket = bucket
-    self._base_path: str = base_path
-    self._chunked_output: Optional[BinaryIO] = None
-
-    # The HTTP server passes *args and *kwargs that we need to pass along, but
-    # don't otherwise care about.  This must happen last, or somehow our
-    # members never get set.
-    super().__init__(rate_limiter, *args, **kwargs)
-
-  def handle_non_chunked(self, path: str, length: int,
-                         file: Union[BinaryIO, BufferedIOBase]) -> None:
-    # No leading slashes, or we get a blank folder name.
-    full_path = (self._base_path + path).strip('/')
-    blob = self._bucket.blob(full_path)
-    blob.cache_control = 'no-cache'
-
-    # If you don't pass size=length, it tries to seek in the file, which fails.
-    blob.upload_from_file(file, size=length,
-                          retry=google.cloud.storage.retry.DEFAULT_RETRY)
-
-  def start_chunked(self, path: str) -> None:
-    # No leading slashes, or we get a blank folder name.
-    full_path = (self._base_path + path).strip('/')
-    blob = self._bucket.blob(full_path)
-    blob.cache_control = 'no-cache'
-
-    self._chunked_output = blob.open(
-        'wb', retry=google.cloud.storage.retry.DEFAULT_RETRY)
-
-  def handle_chunk(self, data: bytes) -> None:
-    assert self._chunked_output is not None
-    self._chunked_output.write(data)
-
-  def end_chunked(self) -> None:
-    assert self._chunked_output is not None
-    self._chunked_output.close()
-    self._chunked_output = None
-
-  def handle_delete(self, path: str) -> None:
-    # No leading slashes, or we get a blank folder name.
-    full_path = (self._base_path + path).strip('/')
-    blob = self._bucket.blob(full_path)
-    try:
-      blob.delete(retry=google.cloud.storage.retry.DEFAULT_RETRY)
-    except google.api_core.exceptions.NotFound:
-      # Some delete calls seem to throw "not found", but the files still get
-      # deleted.  So ignore these and don't fail the request.
-      pass
-
-
-class S3Handler(RequestHandlerBase):
-  # Can't annotate the client here as a parameter if we don't have the library.
-  def __init__(self, client: Any, bucket_name: str, base_path: str,
-               rate_limiter: RateLimiter, *args, **kwargs) -> None:
-    self._client: boto3.client = client
-    self._bucket_name: str = bucket_name
-    self._base_path: str = base_path
-
-    # Used for chunked uploads:
-    self._upload_id: Optional[str] = None
-    self._upload_path: Optional[str] = None
-    self._next_part_number: int = 0
-    self._part_info: list[dict[str,Any]] = []
-    self._data: bytes = b''
-
-    # The HTTP server passes *args and *kwargs that we need to pass along, but
-    # don't otherwise care about.  This must happen last, or somehow our
-    # members never get set.
-    super().__init__(rate_limiter, *args, **kwargs)
-
-  def handle_non_chunked(self, path: str, length: int,
-                         file: Union[BinaryIO, BufferedIOBase]) -> None:
-    # No leading slashes, or we get a blank folder name.
-    full_path = (self._base_path + path).strip('/')
-    # length is unused here.
-    self._client.upload_fileobj(file, self._bucket_name, full_path,
-                                ExtraArgs={'CacheControl': 'no-cache'})
-
-  def start_chunked(self, path: str) -> None:
-    # No leading slashes, or we get a blank folder name.
-    self._upload_path = (self._base_path + path).strip('/')
-    response = self._client.create_multipart_upload(
-        Bucket=self._bucket_name, Key=self._upload_path,
-        CacheControl='no-cache')
-
-    # This ID is sent to subsequent calls into the S3 client.
-    self._upload_id = response['UploadId']
-    self._part_info = []
-    self._next_part_number = 1
-
-    # Multi-part uploads for S3 can't have chunks smaller than 5MB.
-    # We accumulate data for chunks here.
-    self._data = b''
-
-  def handle_chunk(self, data: bytes, force: bool = False) -> None:
-    # Collect data until we hit the minimum chunk size.
-    self._data += data
-
-    data_len = len(self._data)
-    if data_len >= MIN_S3_CHUNK_SIZE or (data_len and force):
-      response = self._client.upload_part(
-          Bucket=self._bucket_name, Key=self._upload_path,
-          PartNumber=self._next_part_number, UploadId=self._upload_id,
-          Body=self._data)
-
-      # We have to collect this data, in this format, to finish the multipart
-      # upload later.
-      self._part_info.append({
-        'PartNumber': self._next_part_number,
-        'ETag': response['ETag'],
-      })
-      self._next_part_number += 1
-      self._data = b''
-
-  def end_chunked(self) -> None:
-    # Flush the buffer.
-    self.handle_chunk(b'', force=True)
-
-    # Complete the multipart upload.
-    upload_info = { 'Parts': self._part_info }
-    self._client.complete_multipart_upload(
-        Bucket=self._bucket_name, Key=self._upload_path,
-        UploadId=self._upload_id, MultipartUpload=upload_info)
-    self._upload_id = None
-    self._upload_path = None
-    self._next_part_number = 0
-    self._part_info = []
-
-  def handle_delete(self, path: str) -> None:
-    self._client.delete_object(
-        Bucket=self._bucket_name, Key=self._upload_path)
-
-
-class HTTPUploadBase(ThreadedNodeBase):
+class ProxyNode(ThreadedNodeBase):
   """Runs an HTTP server at `self.server_location` to upload to cloud.
 
   Subclasses handle upload to specific cloud storage providers.
 
   The local HTTP server at `self.server_location` can only ingest PUT requests.
   """
-  server: Optional[ThreadingHTTPServer] = None
-  server_location: str = ''
-  server_thread: Optional[threading.Thread] = None
+  SUPPORTED_PROTOCOLS = SUPPORTED_PROTOCOLS
+  ALL_SUPPORTED_PROTOCOLS = ALL_SUPPORTED_PROTOCOLS
 
-  def __init__(self) -> None:
+  server_location: str = ''
+
+  def __init__(self, upload_location: str, pool_size: int) -> None:
     super().__init__(thread_name=self.__class__.__name__,
                      continue_on_exception=True,
                      sleep_time=3)
-    self._rate_limiter = RateLimiter()
+    if not ProxyNode.is_supported(upload_location):
+      raise RuntimeError("Protocol of {} isn't supported".format(upload_location))
 
-  @abc.abstractmethod
+    self._upload_location = upload_location
+    self._rate_limiter = RateLimiter()
+    self._server: Optional[ThreadingHTTPServer] = None
+    self._pool: Optional[Pool] = None
+    self._pool_size: int = pool_size
+
   def create_handler(self, *args, **kwargs) -> BaseHTTPRequestHandler:
-    """Returns a cloud-provider-specific request handler to upload to cloud."""
-    pass
+    assert self._pool is not None
+    return RequestHandler(self._rate_limiter, self._pool, *args, **kwargs)
 
   def start(self) -> None:
     # Will be started early to get server location.
-    if self.server is not None:
+    if self._server is not None:
       return
+
+    self._pool = Pool(self._upload_location, self._pool_size)
 
     handler_factory = (
         lambda *args, **kwargs: self.create_handler(*args, **kwargs))
 
     # By specifying port 0, a random unused port will be chosen for the server.
-    self.server = ThreadingHTTPServer(
+    self._server = ThreadingHTTPServer(
         ('localhost', 0), handler_factory)
     self.server_location = (
-        'http://' + self.server.server_name +
-        ':' + str(self.server.server_port))
-
-    self.server_thread = threading.Thread(
-        name=self.server_location, target=self.server.serve_forever)
-    self.server_thread.start()
+        'http://' + self._server.server_name +
+        ':' + str(self._server.server_port))
 
     return super().start()
 
   def stop(self, status: Optional[ProcessStatus]) -> None:
-    if self.server:
-      self.server.shutdown()
-      self.server = None
-    if self.server_thread:
-      self.server_thread.join()
-      self.server_thread = None
+    if self._server:
+      self._server.shutdown()
+      self._server = None
+    if self._pool:
+      self._pool.close()
+      self._pool = None
     return super().stop(status)
 
   def check_status(self) -> ProcessStatus:
@@ -418,60 +238,9 @@ class HTTPUploadBase(ThreadedNodeBase):
     return ProcessStatus.Finished
 
   def _thread_single_pass(self) -> None:
-    # Nothing to do here.
-    return
-
-
-class GCSUpload(HTTPUploadBase):
-  """Upload to Google Cloud Storage."""
-
-  def __init__(self, upload_location: str) -> None:
-    super().__init__()
-
-    url = urllib.parse.urlparse(upload_location)
-    self._client = google.cloud.storage.Client()
-    self._bucket = self._client.bucket(url.netloc)
-    # Strip both left and right slashes.  Otherwise, we get a blank folder name.
-    self._base_path = url.path.strip('/')
-
-  def create_handler(self, *args, **kwargs) -> BaseHTTPRequestHandler:
-    """Returns a cloud-provider-specific request handler to upload to cloud."""
-    return GCSHandler(self._bucket, self._base_path,
-                      self._rate_limiter, *args, **kwargs)
-
-
-class S3Upload(HTTPUploadBase):
-  """Upload to Amazon S3."""
-
-  def __init__(self, upload_location: str) -> None:
-    super().__init__()
-
-    url = urllib.parse.urlparse(upload_location)
-    config = botocore.config.Config(retries = {'mode': 'standard'})
-    self._client = boto3.client('s3', config=config)
-    self._bucket_name = url.netloc
-    # Strip both left and right slashes.  Otherwise, we get a blank folder name.
-    self._base_path = url.path.strip('/')
-
-  def create_handler(self, *args, **kwargs) -> BaseHTTPRequestHandler:
-    """Returns a cloud-provider-specific request handler to upload to cloud."""
-    return S3Handler(self._client, self._bucket_name, self._base_path,
-                     self._rate_limiter, *args, **kwargs)
-
-
-class ProxyNode(object):
-  SUPPORTED_PROTOCOLS = SUPPORTED_PROTOCOLS
-  ALL_SUPPORTED_PROTOCOLS = ALL_SUPPORTED_PROTOCOLS
-
-  @staticmethod
-  def create(upload_location: str) -> HTTPUploadBase:
-    """Creates an upload node based on the protocol used in |upload_location|."""
-    if upload_location.startswith("gs://"):
-      return GCSUpload(upload_location)
-    elif upload_location.startswith("s3://"):
-      return S3Upload(upload_location)
-    else:
-      raise RuntimeError("Protocol of {} isn't supported".format(upload_location))
+    assert self._server is not None
+    # Will terminate on server.shutdown().
+    self._server.serve_forever()
 
   @staticmethod
   def is_understood(upload_location: str) -> bool:


### PR DESCRIPTION
Python's Global Interpreter Lock (GIL) keeps multiple threads from performing as well as they could.  Although the HTTP server is threaded, those threads are not able to upload to cloud storage with the degree of parallelism you might expect.  This leads to an overall drop in the pipeline throughput, and live streams get behind.

This change refactors cloud uploads to use a pool of subprocesses.  Data from the threaded HTTP server is sent via IPC to a subprocess from a pool.  Several subprocesses then upload in parallel, while the main process can continue serving HTTP requests.

The refactor also splits up a large, unreadable module into smaller ones that are (hopefully) clearer.

The IPC mechanism provided by the multiprocessing module has a 64kB buffer, so if these queues back up, this will be reflected in the overall throughput rate logged by ffmpeg.  This is good.  If the system were willing to consume more memory to buffer waiting uploads, the pipeline might show 1x throughput right up until it dies with an out-of-memory error.

The speed-up is significant.  Issues with throughput that I previously attributed to encoding time were actually due to inefficiencies in upload.