### PR TITLE
fix: Add missing dependency on typing_extensions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 distro>=1.9,<2; platform_system == "Linux"
-setproctitle>=1,<2
-pyyaml>=6,<7
 pywin32>=308; platform_system == "Windows"
+pyyaml>=6,<7
+setproctitle>=1,<2
+typing_extensions>=4,<5

--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,10 @@ setuptools.setup(
   url='https://github.com/shaka-project/shaka-streamer',
   packages=setuptools.find_packages(),
   install_requires=[
-      'setproctitle>=1,<2',
-      'pyyaml>=6,<7',
       'pywin32>=308; platform_system == "Windows"',
+      'pyyaml>=6,<7',
+      'setproctitle>=1,<2',
+      'typing_extensions>=4,<5',
   ],
   scripts=['shaka-streamer'],
   classifiers=[


### PR DESCRIPTION
This dependency was introduced in 1.2.0 to enable `typing` module features not yet standard in Python 3.9, so that everything could be properly typed without requiring newer Python versions yet.