### PR TITLE
ci: Stop using self-hosted Linux/arm64 runners

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -122,9 +122,14 @@ jobs:
           sudo apt -y install chromium
 
           # Running inside a Docker container, we need to kill the sandbox.
+          # We also need to set these XDG environment variables, or else we get
+          # errors like "chrome_crashpad_handler: --database is required".
+          # See https://github.com/hardkoded/puppeteer-sharp/issues/2633
           # Heredocs interpolate variables, so escape the dollar sign below.
           cat >/usr/local/bin/chromium <<EOF
           #!/bin/bash
+          export XDG_CONFIG_HOME=/tmp/.chromium
+          export XDG_CACHE_HOME=/tmp/.chromium
           exec /usr/bin/chromium --no-sandbox "\$@"
           EOF
 

--- a/build-matrix.json
+++ b/build-matrix.json
@@ -14,6 +14,11 @@
       "target_arch": "x64"
     },
     {
+      "os": "ubuntu-24.04-arm",
+      "os_name": "linux",
+      "target_arch": "arm64"
+    },
+    {
       "comment": "Explicit macOS version 13 is required for explicit x64 CPU.",
       "os": "macos-13",
       "os_name": "osx",
@@ -32,12 +37,7 @@
     }
   ],
 
-  "comment2": "runners hosted by the owner, enabled by the ENABLE_SELF_HOSTED variable being set on the repo",
+  "comment2": "Self-hosted runners are not used since the introduction of GitHub-hosted Linux arm64 runners.  The feature still exists if a new platform becomes necessary.",
   "selfHosted": [
-    {
-      "os": "self-hosted-linux-arm64",
-      "os_name": "linux",
-      "target_arch": "arm64"
-    }
   ]
 }


### PR DESCRIPTION
These are no longer required since GitHub launched their own Linux/arm64 runners.

See https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/