### PR TITLE
ci: Switch pull_request_target to pull_request

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -7,7 +7,7 @@ name: Build and Test
 #
 # Can also be run manually for debugging purposes.
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
@@ -30,12 +30,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Configure the build matrix based on repo variables.  The list of objects in
-  # the build matrix contents can't be changed by conditionals, but it can be
-  # computed by another job and deserialized.  This uses
-  # vars.ENABLE_SELF_HOSTED to determine the build matrix, based on the
-  # metadata in build-matrix.json.
+  settings:
+    name: Settings
+    uses: ./.github/workflows/settings.yaml
+
+  # Configure the build matrix based on inputs.  The list of objects in the
+  # build matrix contents can't be changed by conditionals, but it can be
+  # computed by another job and deserialized.
   matrix_config:
+    needs: settings
     runs-on: ubuntu-latest
     outputs:
       MATRIX: ${{ steps.configure.outputs.MATRIX }}
@@ -50,11 +53,11 @@ jobs:
         shell: node {0}
         run: |
           const fs = require('fs');
-          const enableDebug = "${{ vars.ENABLE_DEBUG }}" != '';
-          const enableSelfHosted = "${{ vars.ENABLE_SELF_HOSTED }}" != '';
+          const enableDebug = '${{ needs.settings.debug }}' != '';
+          const enableSelfHosted = '${{ needs.settings.self_hosted }}' != '';
 
-          // Use ENABLE_SELF_HOSTED to decide what the build matrix below
-          // should include.
+          // Use enableSelfHosted to decide what the build matrix below should
+          // include.
           const buildMatrix = JSON.parse(fs.readFileSync("${{ github.workspace }}/build-matrix.json"));
           const {hosted, selfHosted, pythonVersions} = buildMatrix;
           const devices = enableSelfHosted ? hosted.concat(selfHosted) : hosted;
@@ -72,16 +75,11 @@ jobs:
               process.env['GITHUB_OUTPUT'],
               `MATRIX=${ JSON.stringify(matrix) }\n`);
 
-          // Output the debug flag directly.
-          fs.appendFileSync(
-              process.env['GITHUB_OUTPUT'],
-              `ENABLE_DEBUG=${ enableDebug }\n`);
-
           // Log the outputs, for the sake of debugging this script.
           console.log({enableDebug, enableSelfHosted, matrix});
 
   build_and_test:
-    needs: matrix_config
+    needs: [settings, matrix_config]
     strategy:
       # Let other matrix entries complete, so we have all results on failure
       # instead of just the first failure.
@@ -199,4 +197,4 @@ jobs:
         uses: mxschmitt/action-tmate@v3.6
         with:
           limit-access-to-actor: true
-        if: failure() && vars.ENABLE_DEBUG != ''
+        if: failure() && needs.settings.debug != ''

--- a/.github/workflows/settings.yaml
+++ b/.github/workflows/settings.yaml
@@ -1,0 +1,52 @@
+# Copyright 2022 Google LLC
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+# A reusable workflow to extract settings from a repository.
+# To enable a setting, create a "GitHub Environment" with the same name.
+#
+# This enables per-repo settings that aren't copied to a fork.  This is better
+# than "vars" or "secrets", since those would require the use of
+# `pull_request_target` instead of `pull_request` triggers, which come with
+# additional risks such as the bypassing of "require approval" rules for
+# workflows.
+#
+# Without a setting for flags like "self_hosted", test workflows for a fork
+# would time out waiting for self-hosted runners that the fork doesn't have.
+name: Settings
+
+# Runs when called from another workflow.
+on:
+  workflow_call:
+    outputs:
+      self_hosted:
+        description: "Enable jobs requiring a self-hosted runner."
+        value: ${{ jobs.settings.outputs.self_hosted }}
+      debug:
+        description: "Enable SSH debugging when a workflow fails."
+        value: ${{ jobs.settings.outputs.debug }}
+
+jobs:
+  settings:
+    runs-on: ubuntu-latest
+    outputs:
+      self_hosted: ${{ steps.settings.outputs.self_hosted }}
+      debug: ${{ steps.settings.outputs.debug }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - id: settings
+        run: |
+          environments=$(gh api /repos/${{ github.repository }}/environments)
+          for name in self_hosted debug; do
+            exists=$(echo $environments | jq ".environments[] | select(.name == \"$name\")")
+            if [[ "$exists" != "" ]]; then
+              echo "$name=true" >> $GITHUB_OUTPUT
+              echo "\"$name\" enabled."
+            else
+              echo "$name=" >> $GITHUB_OUTPUT
+              echo "\"$name\" disabled."
+            fi
+          done


### PR DESCRIPTION
With this change, GitHub will start to enforce "require approval" settings for the repo, which `pull_request_target` allows PR authors to get around.

To stop using `pull_request_target`, we also have to stop using `vars`, which are not available on `pull_request` triggers.  Instead, we use the "environments" trick used by Shaka Packager's workflows before `vars` was introduced to GitHub Actions.  This is a safer system.