### PR TITLE
fix: Fix missing cloud/ subfolder

### DIFF
--- a/streamer/cloud/__init__.py
+++ b/streamer/cloud/__init__.py
@@ -1,0 +1,1 @@
+from . import *


### PR DESCRIPTION
The cloud/ folder was added in 1.2.0, but was not being packaged correctly due to a missing `__init__.py` file.  This bug affected the 1.2.0 and 1.2.1 releases, making both unusable.

Fixes #234