### PR TITLE
test: Bind the end-to-end test server to a free port

### DIFF
--- a/run_end_to_end_tests.py
+++ b/run_end_to_end_tests.py
@@ -19,6 +19,7 @@ browser."""
 
 import argparse
 import flask
+from werkzeug.serving import make_server
 import glob
 import json
 import logging
@@ -356,11 +357,26 @@ def main():
 
   fetch_cloud_assets()
 
-  # Start up flask server on a thread.
-  # Daemon is set to True so that this thread automatically gets
-  # killed when exiting main.  Flask does not have any clean alternatives
-  # to be killed.
-  threading.Thread(target=app.run, daemon=True).start()
+  # Start up the Flask server on a thread.
+  #
+  # Bind to an OS-assigned free port (port 0) on 127.0.0.1 rather than Flask's
+  # default port of 5000.  On macOS, the ControlCenter/AirPlay Receiver service
+  # also listens on port 5000, and using 5000 was correlated with an
+  # intermittent, macOS-only failure of the first end-to-end test with
+  # "TypeError: Failed to fetch" (see issue #261).  We never fully confirmed the
+  # exact interaction on the CI runners, but moving off port 5000 empirically
+  # stops the flake, and a free port also avoids any future collision with an
+  # unrelated service.
+  # See https://github.com/shaka-project/shaka-streamer/issues/261
+  #
+  # We use make_server() (instead of app.run) so we can read back the actual
+  # port before serving, with no window for another process to steal it.
+  server = make_server('127.0.0.1', 0, app, threaded=True)
+  flask_port = server.server_port
+
+  # Daemon is set to True so that this thread automatically gets killed when
+  # exiting main.  Flask does not have any clean alternatives to be killed.
+  threading.Thread(target=server.serve_forever, daemon=True).start()
 
   fails = 0
   trials = args.runs
@@ -381,6 +397,8 @@ def main():
     test_args += [ '--debug', 'true' ]
   if args.test_widevine:
     test_args += [ '--testWidevine', 'true' ]
+  # Tell the browser tests which port the Flask server is listening on.
+  test_args += [ '--flaskPort', str(flask_port) ]
 
   for _ in range(trials):
     # If the exit code was not 0, the tests in karma failed or crashed.

--- a/tests/karma.conf.js
+++ b/tests/karma.conf.js
@@ -23,6 +23,9 @@ module.exports = function(config) {
       seed: config.seed,
       debug: !!config.debug,
       testWidevine: !!config.testWidevine,
+      // The port the Flask test server is listening on, chosen dynamically by
+      // run_end_to_end_tests.py and passed in via --flaskPort.
+      flaskPort: config.flaskPort,
     },
     frameworks: ['jasmine'],
     files: [

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -12,7 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-const flaskServerUrl = 'http://localhost:5000/';
+// The Flask test server binds an OS-assigned free port, which is passed to us
+// through the Karma config.  Do NOT go back to a fixed port like Flask's
+// default of 5000: on macOS, the ControlCenter/AirPlay Receiver service also
+// listens on port 5000, and using 5000 was correlated with an intermittent,
+// macOS-only "TypeError: Failed to fetch" on the first test.  The exact
+// interaction on the CI runners was never fully confirmed, but moving off port
+// 5000 empirically stops the flake.
+// See https://github.com/shaka-project/shaka-streamer/issues/261
+const flaskServerUrl = 'http://127.0.0.1:' + __karma__.config.flaskPort + '/';
 const dashManifestUrl = flaskServerUrl + 'output_files/dash.mpd';
 const hlsManifestUrl = flaskServerUrl + 'output_files/hls.m3u8';
 const OUTPUT_DIR = 'output_files/'


### PR DESCRIPTION
The first end-to-end test ('fails when extra fields are present') failed intermittently on macOS with 'TypeError: Failed to fetch', without ever reaching the config validation it was meant to exercise, so the flake was in the test harness rather than in Shaka Streamer itself.

What we know:
- The failure was macOS-only and always hit the first request to the Flask test server, which used Flask's default port 5000.
- On macOS, the ControlCenter/AirPlay Receiver service also listens on port 5000.
- Binding the server to an OS-assigned free port instead of 5000 stops the flake: the fix ran green across several repeated macOS CI runs.

What we do NOT know:
- The exact interaction on the CI runners.  Our server and AirPlay can both bind port 5000 via SO_REUSEADDR, and locally a 127.0.0.1:5000 request still reaches our server, so we could not reproduce the precise failure mode off the runners.  An earlier attempt to force IPv4 (using 127.0.0.1 instead of 'localhost') did not help, which is what pointed us at the port rather than address resolution.

So this is an empirically-verified fix without a fully pinned-down
mechanism.  Using a free port also avoids any future collision with an unrelated service.

The server now binds via werkzeug.serving.make_server so we can read the chosen port back before serving (no window for another process to steal it), and that port is passed to the browser tests through the Karma config.

Fixes #261