### PR TITLE
docs: Document multi-DRM with a Widevine key server

### DIFF
--- a/config_files/pipeline_vod_encrypted_config.yaml
+++ b/config_files/pipeline_vod_encrypted_config.yaml
@@ -59,6 +59,12 @@ encryption:
   signing_key: 1ae8ccd0e7985cc0b6203a55855a1034afc252980e970ca90e5202689f947ab9
   # AES signing iv in hex string.
   signing_iv: d58ce954203b7c9a9a9d467f59839249
+  # Optional protection systems to signal in the output.  These are generated
+  # from the keys fetched above, so a single Widevine key server request can
+  # package the content for several DRM systems at once.
+  protection_systems:
+    - Widevine
+    - PlayReady
   # Protection scheme (cenc or cbcs)
   # These are different methods of using a block cipher to encrypt media.
   protection_scheme: cenc

--- a/streamer/pipeline_configuration.py
+++ b/streamer/pipeline_configuration.py
@@ -125,8 +125,15 @@ class EncryptionConfig(configuration.Base):
   to raw."""
 
   protection_systems = configuration.Field(List[ProtectionSystem]).cast()
-  """Protection Systems to be generated. Supported protection systems include
-  Widevine, PlayReady, FairPlay, Marin and CommonSystem.
+  """Protection systems to be generated. Supported protection systems include
+  Widevine, PlayReady, FairPlay, Marlin and CommonSystem.
+
+  Applies to both encryption modes.  The protection systems signalled in the
+  output are independent of where the keys came from, so in 'widevine'
+  encryption_mode you can list several systems here and a single fetch from
+  the Widevine key server will produce PSSH boxes for all of them.  For
+  example, listing Widevine and PlayReady packages the content for both
+  without any manually-supplied keys.
   """
 
   pssh = configuration.Field(configuration.HexString).cast()

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -625,6 +625,56 @@ function drmTests(manifestUrl, format) {
     await player.load(manifestUrl);
   });
 
+  it('can signal multiple protection systems from Widevine keys ' + format,
+      async () => {
+    if (!testWidevine) {
+      pending('Skipped due to command line flag');
+    }
+
+    const inputConfigDict = {
+      'inputs': [
+        {
+          'name': TEST_DIR + 'BigBuckBunny.1080p.mp4',
+          'media_type': 'video',
+          // Keep this test short by only encoding 1s of content.
+          'end_time': '0:01',
+        },
+      ]
+    };
+    const pipelineConfigDict = {
+      'streaming_mode': 'vod',
+      'resolutions': ['144p'],
+      'encryption': {
+        // Enables encryption.
+        'enable': true,
+        // The keys still come from the Widevine key server, but the PSSH
+        // generators are independent of the key source, so PlayReady can be
+        // signalled too without any manually-supplied keys.
+        'protection_systems': ['Widevine', 'PlayReady'],
+        'clear_lead': 0,
+      },
+    };
+
+    await startStreamer(inputConfigDict, pipelineConfigDict);
+    await debugManifest(manifestUrl);
+
+    // We can't play PlayReady content in the test browser, so check the
+    // manifest for the signalling of both systems instead.
+    const response = await fetchRetry(manifestUrl);
+    const manifestText = await response.text();
+
+    if (manifestUrl.includes('hls.m3u8')) {
+      expect(manifestText).toContain(
+          'KEYFORMAT="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"');
+      expect(manifestText).toContain('KEYFORMAT="com.microsoft.playready"');
+    } else {
+      expect(manifestText).toContain(
+          'schemeIdUri="urn:uuid:edef8ba9-79d6-4ace-a3c8-27dcd51d21ed"');
+      expect(manifestText).toContain(
+          'schemeIdUri="urn:uuid:9a04f079-9840-4286-ab92-e65be0885f95"');
+    }
+  });
+
   it('has raw key encryption enabled ' + format, async () => {
     const inputConfigDict = {
       'inputs': [


### PR DESCRIPTION
The encryption.protection_systems field already applies to both encryption modes, but its docstring sat among the raw-key-only fields without the "Applies to ..." note that its neighbors carry, so it read as raw-only. Clarify that it works with the Widevine key server too, where a single key fetch can produce PSSH boxes for several protection systems.

Also fix a "Marin"/"Marlin" typo, show the field in the Widevine sample config, and add a test covering Widevine + PlayReady from Widevine-fetched keys.