### PR TITLE
feat: Add scene_detection option for uniform segment sizes

### DIFF
--- a/streamer/pipeline_configuration.py
+++ b/streamer/pipeline_configuration.py
@@ -299,6 +299,21 @@ class PipelineConfig(configuration.Base):
   used.
   """
 
+  scene_detection = configuration.Field(bool, default=True).cast()
+  """If true, the video encoder may insert an extra keyframe wherever it
+  detects a scene change.
+
+  A scene-change keyframe restarts the encoder's GOP counter, so subsequent
+  keyframes drift off the fixed grid implied by segment_size.  Shaka Packager
+  can only begin a segment on a keyframe, so the segments it writes end up
+  uneven.  Set this to false to keep every keyframe on the grid and get
+  segments of a uniform length, at some cost in compression efficiency.
+
+  Only supported for software h264 and hevc encoding.  The other encoders
+  don't expose a way to turn scene detection off, so this must be left true
+  for them.
+  """
+
   manifest_format = configuration.Field(List[ManifestFormat],
                                         default=[
                                             ManifestFormat.DASH,
@@ -377,6 +392,23 @@ class PipelineConfig(configuration.Base):
       reason = 'must be true when streaming_mode is "live"'
       raise configuration.MalformedField(
           self.__class__, 'segment_per_file', field, reason)
+
+    if not self.scene_detection:
+      # Rather than silently ignore the setting, reject the codecs we have no
+      # way to turn scene detection off for.
+      software_codecs = {bitrate_configuration.VideoCodec.H264,
+                         bitrate_configuration.VideoCodec.HEVC}
+      unsupported = [
+          ('hw:' if codec.is_hardware_accelerated() else '') + codec.value
+          for codec in self.video_codecs
+          if codec.is_hardware_accelerated() or codec not in software_codecs
+      ]
+      if unsupported:
+        field = self.__class__.scene_detection
+        reason = ('can only be false for software h264 and hevc encoding, but '
+                  'video_codecs contains ' + ', '.join(unsupported))
+        raise configuration.MalformedField(
+            self.__class__, 'scene_detection', field, reason)
 
   def get_resolutions(self) -> List[bitrate_configuration.VideoResolution]:
     VideoResolution = bitrate_configuration.VideoResolution  # alias

--- a/streamer/transcoder_node.py
+++ b/streamer/transcoder_node.py
@@ -305,6 +305,17 @@ class TranscoderNode(PolitelyWaitOnFinish):
           '-row-mt', '1',
       ]
 
+    if not self._pipeline_config.scene_detection:
+      # Without this, the encoder inserts an extra keyframe at each scene
+      # change, which restarts its GOP counter and drifts the later keyframes
+      # off the grid implied by segment_size.  PipelineConfig has already
+      # rejected the codecs that have no way to turn this off.
+      if stream.codec == VideoCodec.HEVC:
+        # libx265 ignores -sc_threshold and needs its own private option.
+        args += ['-x265-params', 'scenecut=0']
+      else:
+        args += ['-sc_threshold', '0']
+
     keyframe_interval = int(self._pipeline_config.segment_size *
                             media_input.frame_rate)
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -204,6 +204,10 @@ describe('Shaka Streamer', () => {
   durationTests(hlsManifestUrl, '(hls)');
   durationTests(dashManifestUrl, '(dash)');
 
+  // Only the DASH manifest lists the duration of each individual segment, so
+  // only test this in DASH.
+  sceneDetectionTests(dashManifestUrl, '(dash)');
+
   mapTests(hlsManifestUrl, '(hls)');
   mapTests(dashManifestUrl, '(dash)');
 
@@ -380,6 +384,23 @@ function errorTests() {
         .toBeRejectedWith(jasmine.objectContaining({
           error_type: 'MalformedField',
           field_name: 'segment_per_file',
+        }));
+  });
+
+  it('fails when scene_detection is off for an unsupported codec', async () => {
+    const inputConfig = getBasicInputConfig();
+    const pipelineConfig = {
+      streaming_mode: 'vod',
+      resolutions: ['144p'],
+      // Only the software h264 and hevc encoders can turn scene detection off.
+      video_codecs: ['vp9'],
+      scene_detection: false,
+    };
+
+    await expectAsync(startStreamer(inputConfig, pipelineConfig))
+        .toBeRejectedWith(jasmine.objectContaining({
+          error_type: 'MalformedField',
+          field_name: 'scene_detection',
         }));
   });
 
@@ -1260,6 +1281,63 @@ function durationTests(manifestUrl, format) {
 
     // We took from 2-5, so the output should be about 3 seconds long.
     expect(video.duration).toBeCloseTo(3, 1 /* decimal points to check */);
+  });
+}
+
+function sceneDetectionTests(manifestUrl, format) {
+  const SEGMENT_SIZE = 2;
+
+  it('produces uniform segments with scene detection off ' + format,
+      async() => {
+    const inputConfigDict = {
+      'inputs': [
+        {
+          // This clip is 10 seconds long and has scene changes in it, so with
+          // scene detection left on, the segments come out uneven.
+          'name': TEST_DIR + 'Sintel.2010.720p.Small.mkv',
+          'media_type': 'video',
+        },
+      ],
+    };
+    const pipelineConfigDict = {
+      'streaming_mode': 'vod',
+      'resolutions': ['144p'],
+      'video_codecs': ['h264'],
+      'segment_size': SEGMENT_SIZE,
+      'scene_detection': false,
+    };
+
+    await startStreamer(inputConfigDict, pipelineConfigDict);
+    await debugManifest(manifestUrl);
+
+    const response = await fetchRetry(manifestUrl);
+    const mpd = new DOMParser().parseFromString(
+        await response.text(), 'application/xml');
+
+    const videoSet = Array.from(mpd.getElementsByTagName('AdaptationSet'))
+        .find((set) => set.getAttribute('contentType') == 'video');
+    const template = videoSet.getElementsByTagName('SegmentTemplate')[0];
+    const timescale = parseInt(template.getAttribute('timescale'), 10);
+
+    const durations = [];
+    for (const s of template.getElementsByTagName('S')) {
+      const d = parseInt(s.getAttribute('d'), 10);
+      // "r" is the number of _additional_ repeats, and defaults to 0.
+      const repeats = parseInt(s.getAttribute('r') || '0', 10);
+      for (let i = 0; i <= repeats; i++) {
+        durations.push(d);
+      }
+    }
+
+    // Make sure we got enough segments for this to mean anything.
+    expect(durations.length).toBeGreaterThan(3);
+
+    // The first segment absorbs any timestamp offset in the input, and the
+    // last one is whatever is left over, so neither is expected to be a full
+    // segment.  Everything in between should be exact.
+    for (const duration of durations.slice(1, -1)) {
+      expect(duration).toBe(SEGMENT_SIZE * timescale);
+    }
   });
 }
 


### PR DESCRIPTION
The video encoder inserts an extra keyframe at each scene change, which restarts its GOP counter.  Later keyframes then drift off the grid implied by segment_size, and since Packager can only start a segment on a keyframe, the segments come out uneven.  On a 60s slice of Sintel at segment_size 8, the segments ranged from 4.4s to 12.2s.

Add a pipeline option to turn scene detection off, via -sc_threshold for h264 and -x265-params scenecut=0 for hevc.  With it off, that same slice gives seven segments of exactly 8.000s plus a 4.000s remainder.

Defaults to true, so existing configs are unaffected.  libvpx and libaom expose no equivalent knob and would silently ignore the setting, so setting it false alongside those codecs (or a hardware encoder) is rejected rather than quietly disregarded.